### PR TITLE
Improve site layout with navigation and footer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,8 +6,21 @@ export default function AboutPage() {
   return (
     <div className="container mx-auto px-4 py-12">
       <h1 className="text-3xl font-bold mb-6 text-gray-800">센터 소개</h1>
-      <p className="mb-4">라라재가 요양센터는 전문 요양 서비스를 제공하는 곳입니다. 가족같이 따뜻한 돌봄을 약속드립니다.</p>
-      <p className="mb-8">방문 요양과 가족 요양 등 다양한 프로그램을 운영하고 있습니다.</p>
+      <div className="mb-8">
+        <img
+          src="https://images.unsplash.com/photo-1500622944204-b135684e99fd?auto=format&fit=crop&w=1200&q=80"
+          alt="센터 이미지"
+          className="w-full h-64 object-cover rounded-lg mb-6"
+        />
+        <p className="mb-4">
+          라라재가 요양센터는 어르신의 행복한 일상을 위해 최선을 다합니다. 전문 요양보호사가 맞춤형 서비스를 제공하며,
+          가족처럼 따뜻한 돌봄을 약속드립니다.
+        </p>
+        <p className="mb-4">
+          주요 서비스로는 방문요양, 방문목욕, 방문간호 등이 있으며, 신체·정서·인지 활동을 종합적으로 지원합니다.
+        </p>
+        <p className="mb-8">항상 열린 마음으로 상담해 드리니 궁금한 점이 있으면 언제든지 문의해 주세요.</p>
+      </div>
       <a href="/" className="text-blue-600 hover:underline">첫 화면으로 돌아가기</a>
     </div>
   );

--- a/src/app/find/page.tsx
+++ b/src/app/find/page.tsx
@@ -13,7 +13,9 @@ export default function FindPage() {
           loading="lazy"
         ></iframe>
       </div>
-      <p className="mb-8">서울특별시 어딘가에 위치하고 있습니다.</p>
+      <p className="mb-2">주소: 서울특별시 어딘가 1234</p>
+      <p className="mb-2">전화: 02-1234-5678</p>
+      <p className="mb-8">운영시간: 평일 09:00 ~ 18:00 (주말/공휴일 휴무)</p>
       <a href="/" className="text-blue-600 hover:underline">첫 화면으로 돌아가기</a>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -18,13 +20,17 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({
-	children,
+        children,
 }: Readonly<{
-	children: React.ReactNode;
+        children: React.ReactNode;
 }>) {
-	return (
-		<html lang="ko">
-			<body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
-		</html>
-	);
+        return (
+                <html lang="ko">
+                        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}> 
+                                <Navbar />
+                                {children}
+                                <Footer />
+                        </body>
+                </html>
+        );
 }

--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -1,11 +1,22 @@
 "use client";
 
 import HeroSection from "./HeroSection";
+import ServiceSection from "./ServiceSection";
+import ContactModal from "./ContactModal";
+import { useState } from "react";
 
 const ClientProvider = () => {
+  const [showContact, setShowContact] = useState(false);
+
   return (
     <>
       <HeroSection />
+      <ServiceSection setShowContact={setShowContact} />
+      <ContactModal
+        showContact={showContact}
+        setShowContact={setShowContact}
+        context="홈페이지 문의"
+      />
     </>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+const Footer = () => {
+  return (
+    <footer className="bg-gray-800 text-gray-200 mt-12">
+      <div className="container mx-auto px-4 py-10">
+        <h3 className="text-lg font-semibold mb-2">라라재가 요양센터</h3>
+        <p>주소: 서울특별시 어딘가 1234</p>
+        <p>전화: 02-1234-5678</p>
+        <p className="mb-4">이메일: info@example.com</p>
+        <p className="text-sm text-gray-400">
+          © {new Date().getFullYear()} Lara Homecare. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const Navbar = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="bg-white shadow sticky top-0 z-20">
+      <div className="container mx-auto flex items-center justify-between px-4 py-3">
+        <Link href="/" className="text-xl font-semibold text-gray-800">
+          라라재가 요양센터
+        </Link>
+        <nav className="hidden md:flex space-x-6 text-gray-700">
+          <Link href="/about" className="hover:text-gray-900">
+            센터 소개
+          </Link>
+          <Link href="/find" className="hover:text-gray-900">
+            오시는 길
+          </Link>
+        </nav>
+        <button
+          onClick={() => setOpen(!open)}
+          className="md:hidden text-gray-700 hover:text-gray-900"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={
+                open
+                  ? "M6 18L18 6M6 6l12 12"
+                  : "M4 6h16M4 12h16M4 18h16"
+              }
+            />
+          </svg>
+        </button>
+      </div>
+      {open && (
+        <nav className="md:hidden bg-white border-t border-gray-200">
+          <div className="px-4 py-2 flex flex-col space-y-2 text-gray-700">
+            <Link href="/" onClick={() => setOpen(false)} className="hover:text-gray-900">
+              홈
+            </Link>
+            <Link href="/about" onClick={() => setOpen(false)} className="hover:text-gray-900">
+              센터 소개
+            </Link>
+            <Link href="/find" onClick={() => setOpen(false)} className="hover:text-gray-900">
+              오시는 길
+            </Link>
+          </div>
+        </nav>
+      )}
+    </header>
+  );
+};
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- add Navbar and Footer components
- include site-wide navigation and footer via layout
- expand home page provider with services and contact modal
- flesh out about page with sample image and details
- expand find page with address and hours

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68515c060c50832ba68d767faa1fa356