### PR TITLE
Refine landing page design

### DIFF
--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -1,24 +1,9 @@
 "use client";
 
 import HeroSection from "./HeroSection";
-import ServiceSection from "./ServiceSection";
-import ContactModal from "./ContactModal";
-import { useState } from "react";
 
 const ClientProvider = () => {
-  const [showContact, setShowContact] = useState(false);
-
-  return (
-    <>
-      <HeroSection />
-      <ServiceSection setShowContact={setShowContact} />
-      <ContactModal
-        showContact={showContact}
-        setShowContact={setShowContact}
-        context="홈페이지 문의"
-      />
-    </>
-  );
+  return <HeroSection />;
 };
 
 export default ClientProvider;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -9,7 +9,7 @@ const HeroSection = () => {
   const [showChoices, setShowChoices] = useState(false);
 
   return (
-    <div className="relative overflow-hidden bg-gradient-to-r from-blue-700 to-indigo-800 text-white">
+    <div className="relative overflow-hidden bg-gradient-to-r from-blue-700 to-indigo-800 text-white min-h-screen flex items-center justify-center">
       <div className="absolute inset-0 z-0 opacity-20">
         <Image
           src="https://images.unsplash.com/photo-1576091160550-2173dba999ef?ixlib=rb-1.2.1&auto=format&fit=crop&w=1200&q=80"
@@ -20,7 +20,7 @@ const HeroSection = () => {
           priority
         />
       </div>
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-24 relative z-10">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <div className="max-w-3xl mx-auto text-center">
           <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-shadow">
             <TypewriterText

--- a/src/components/ServiceOptions.tsx
+++ b/src/components/ServiceOptions.tsx
@@ -51,7 +51,7 @@ const ServiceOptions = ({ userType, serviceType, setServiceType }: ServiceOption
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <button
           onClick={() => setServiceType("visit")}
-          className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30"
+          className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
         >
           <div className="text-4xl mb-4">🏠</div>
           <h3 className="text-lg font-semibold mb-2">방문 요양을 원해요</h3>
@@ -59,7 +59,7 @@ const ServiceOptions = ({ userType, serviceType, setServiceType }: ServiceOption
         </button>
         <button
           onClick={() => setServiceType("family")}
-          className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30"
+          className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
         >
           <div className="text-4xl mb-4">👪</div>
           <h3 className="text-lg font-semibold mb-2">가족 요양을 원해요</h3>

--- a/src/components/UserChoiceSection.tsx
+++ b/src/components/UserChoiceSection.tsx
@@ -28,7 +28,7 @@ const UserChoiceSection = () => {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <button
             onClick={handleCenterInfo}
-            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30"
+            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">📍</div>
             <h3 className="text-lg font-semibold mb-2">센터에 대해 알려주세요</h3>
@@ -37,7 +37,7 @@ const UserChoiceSection = () => {
           
           <button
             onClick={() => setUserType("client")}
-            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30"
+            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">👨‍👩‍👧‍👦</div>
             <h3 className="text-lg font-semibold mb-2">요양보호사가 필요합니다</h3>
@@ -46,7 +46,7 @@ const UserChoiceSection = () => {
           
           <button
             onClick={() => setUserType("caregiver")}
-            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30"
+            className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">👩‍⚕️</div>
             <h3 className="text-lg font-semibold mb-2">요양보호사 입니다</h3>
@@ -67,7 +67,7 @@ const UserChoiceSection = () => {
               처음으로 돌아가기
             </button>
             <span className="mx-2 opacity-60">|</span>
-            <div className="text-sm rounded-full bg-white bg-opacity-20 px-3 py-1">
+            <div className="text-sm rounded-full bg-white bg-opacity-20 px-3 py-1 text-gray-900">
               {userType === "client" ? "요양보호사 찾기" : "요양보호사 지원"}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- simplify `ClientProvider` to only show the hero section
- adjust hero section layout to center content and fill the screen
- ensure option buttons display text with dark colors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68515f6e3aa0832b8e0d4876ed5c7b7f