### PR TITLE
Integrate simple shadcn-style button

### DIFF
--- a/src/components/ContactModal.tsx
+++ b/src/components/ContactModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/Button";
 
 interface ContactModalProps {
   showContact: boolean;
@@ -131,19 +132,19 @@ const ContactModal = ({ showContact, setShowContact, context = "" }: ContactModa
               />
             </div>
             <div className="flex flex-col sm:flex-row justify-end gap-4 pt-6">
-              <button
+              <Button
                 type="button"
                 className="px-8 py-4 text-gray-700 rounded-lg border border-gray-300 hover:bg-gray-50 font-medium text-lg"
                 onClick={closeModal}
               >
                 닫기
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 className="px-8 py-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition shadow-md font-medium text-lg"
               >
                 문의하기
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { Button } from "@/components/ui/Button";
 
 const Navbar = () => {
   const [open, setOpen] = useState(false);
@@ -20,7 +21,7 @@ const Navbar = () => {
             오시는 길
           </Link>
         </nav>
-        <button
+        <Button
           onClick={() => setOpen(!open)}
           className="md:hidden text-gray-700 hover:text-gray-900"
         >
@@ -42,7 +43,7 @@ const Navbar = () => {
               }
             />
           </svg>
-        </button>
+        </Button>
       </div>
       {open && (
         <nav className="md:hidden bg-white border-t border-gray-200">

--- a/src/components/ServiceOptions.tsx
+++ b/src/components/ServiceOptions.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import ContactModal from "./ContactModal";
+import { Button } from "@/components/ui/Button";
 
 interface ServiceOptionsProps {
 	userType: "client" | "caregiver";
@@ -50,22 +51,22 @@ const ServiceOptions = ({ userType, serviceType, setServiceType }: ServiceOption
 	if (!serviceType) {
 		return (
 			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-				<button
-					onClick={() => setServiceType("visit")}
-					className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
-				>
-					<div className="text-4xl mb-4">🏠</div>
-					<h3 className="text-lg font-semibold mb-2">방문 요양을 원해요</h3>
-					<p className="text-sm opacity-80">집으로 방문하는 돌봄 서비스</p>
-				</button>
-				<button
-					onClick={() => setServiceType("family")}
-					className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
-				>
-					<div className="text-4xl mb-4">👪</div>
-					<h3 className="text-lg font-semibold mb-2">가족 요양을 원해요</h3>
-					<p className="text-sm opacity-80">가족이 돌봄을 제공하는 서비스</p>
-				</button>
+                                <Button
+                                        onClick={() => setServiceType("visit")}
+                                        className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
+                                >
+                                        <div className="text-4xl mb-4">🏠</div>
+                                        <h3 className="text-lg font-semibold mb-2">방문 요양을 원해요</h3>
+                                        <p className="text-sm opacity-80">집으로 방문하는 돌봄 서비스</p>
+                                </Button>
+                                <Button
+                                        onClick={() => setServiceType("family")}
+                                        className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
+                                >
+                                        <div className="text-4xl mb-4">👪</div>
+                                        <h3 className="text-lg font-semibold mb-2">가족 요양을 원해요</h3>
+                                        <p className="text-sm opacity-80">가족이 돌봄을 제공하는 서비스</p>
+                                </Button>
 			</div>
 		);
 	}
@@ -78,18 +79,15 @@ const ServiceOptions = ({ userType, serviceType, setServiceType }: ServiceOption
 			<p>{detail?.desc}</p>
 			<p className="font-medium">{detail?.price}</p>
 			<div className="flex flex-col sm:flex-row gap-4 justify-center">
-				<Link
-					href="/find"
-					className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition shadow-md font-medium text-center flex-1"
-				>
-					센터를 방문할게요
-				</Link>
-				<button
-					onClick={() => setShowContact(true)}
-					className="px-6 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition shadow-md font-medium flex-1"
-				>
-					문의하고 싶어요
-				</button>
+                                <Link href="/find" className="flex-1">
+                                        <Button className="w-full px-6 py-3">센터를 방문할게요</Button>
+                                </Link>
+                                <Button
+                                        onClick={() => setShowContact(true)}
+                                        className="px-6 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition shadow-md font-medium flex-1"
+                                >
+                                        문의하고 싶어요
+                                </Button>
 			</div>
 			<ContactModal showContact={showContact} setShowContact={setShowContact} context={contextMsg} />
 		</div>

--- a/src/components/UserChoiceSection.tsx
+++ b/src/components/UserChoiceSection.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import ServiceOptions from "./ServiceOptions";
+import { Button } from "@/components/ui/Button";
 
 type UserType = "client" | "caregiver" | null;
 type ServiceType = "visit" | "family" | null;
@@ -26,38 +27,38 @@ const UserChoiceSection = () => {
       {!userType ? (
         // 초기 사용자 유형 선택
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <button
+          <Button
             onClick={handleCenterInfo}
             className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">📍</div>
             <h3 className="text-lg font-semibold mb-2">센터에 대해 알려주세요</h3>
             <p className="text-sm opacity-80">센터 소개와 위치를 확인하세요</p>
-          </button>
+          </Button>
           
-          <button
+          <Button
             onClick={() => setUserType("client")}
             className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">👨‍👩‍👧‍👦</div>
             <h3 className="text-lg font-semibold mb-2">요양보호사가 필요합니다</h3>
             <p className="text-sm opacity-80">어르신을 위한 요양 서비스 신청</p>
-          </button>
+          </Button>
           
-          <button
+          <Button
             onClick={() => setUserType("caregiver")}
             className="bg-white bg-opacity-20 hover:bg-opacity-30 backdrop-blur-sm p-6 rounded-xl shadow-md transition transform hover:-translate-y-1 border border-white border-opacity-30 text-gray-900"
           >
             <div className="text-4xl mb-4">👩‍⚕️</div>
             <h3 className="text-lg font-semibold mb-2">요양보호사 입니다</h3>
             <p className="text-sm opacity-80">요양보호사 지원 및 문의</p>
-          </button>
+          </Button>
         </div>
       ) : (
         // 서비스 유형 선택 또는 서비스 상세 정보 표시
         <>
           <div className="flex items-center justify-center mb-8">
-            <button
+            <Button
               onClick={resetSelections}
               className="flex items-center text-white hover:underline mr-2"
             >
@@ -65,7 +66,7 @@ const UserChoiceSection = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7"></path>
               </svg>
               처음으로 돌아가기
-            </button>
+            </Button>
             <span className="mx-2 opacity-60">|</span>
             <div className="text-sm rounded-full bg-white bg-opacity-20 px-3 py-1 text-gray-900">
               {userType === "client" ? "요양보호사 찾기" : "요양보호사 지원"}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        'bg-blue-600 text-white hover:bg-blue-700',
+        className
+      )}
+      {...props}
+    />
+  )
+})
+Button.displayName = 'Button'
+
+export { Button }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- create `cn` helper
- add a basic shadcn-style `Button` component
- refactor modal, service options, user choice section and navbar to use new button

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685786084200832b8024008a6aed4ea1